### PR TITLE
Set ^ operator precedence to higher than * and /

### DIFF
--- a/src/parser/Parser.js
+++ b/src/parser/Parser.js
@@ -28,7 +28,9 @@ import {
  *
  * addExp : mulExp ((PLUS | MINUS | CONCAT) mulExp)* ;
  *
- * mulExp : term ((MULT | DIV | EXP) term)* ;
+ * mulExp : expExp ((MULT | DIV) expExp)* ;
+ *
+ * expExp : term ((EXP) term)* ;
  *
  * term : (PLUS | MINUS) factor (PERCENT)? ;
  *
@@ -169,19 +171,43 @@ export default class Parser
     }
 
     /**
-     * Multiplication, division and Pow rule.
+     * Multiplication and division rule.
      *
      * @example <caption>Grammar:</caption>
      *
-     * mulExp : term ((MULT | DIV | EXP) term)* ;
+     * mulExp : expExp ((MULT | DIV) expExp)* ;
      *
      * @return {AST} Abstract Syntax tree.
      */
     mulExp()
     {
+        let node = this.expExp();
+
+        while ([TOKENS.MULT, TOKENS.DIV].includes(this.lookahead.type))
+        {
+            const token = this.lookahead;
+
+            this.match(token.type);
+            node = new BinOp(node, token, this.expExp());
+        }
+
+        return node;
+    }
+
+    /**
+     * Exponentiation rule.
+     *
+     * @example <caption>Grammar:</caption>
+     *
+     * expExp : term ((EXP) term)* ;
+     *
+     * @return {AST} Abstract Syntax tree.
+     */
+    expExp()
+    {
         let node = this.term();
 
-        while ([TOKENS.MULT, TOKENS.DIV, TOKENS.POW].includes(this.lookahead.type))
+        while ([TOKENS.POW].includes(this.lookahead.type))
         {
             const token = this.lookahead;
 

--- a/test/parser/Parser.js
+++ b/test/parser/Parser.js
@@ -185,5 +185,26 @@ describe('Parser', () =>
             parser.lexer = lexer;
             expect(parser.parse).to.throwError();
         });
+
+        describe('operator precedence', () => {
+            describe('^', () => {
+                it('should have higher precedence than multiplication', () => {
+                    let formula;
+
+                    formula = `= 4 * 2 ^ 7`;
+                    expect(parseText(formula)).to.be.eql(
+                        new BinOp(
+                            new NumberConstant(4),
+                            new Token(TOKENS.MULT, '*'),
+                            new BinOp(
+                                new NumberConstant(2),
+                                new Token(TOKENS.POW, '^'),
+                                new NumberConstant(7)
+                            )
+                        )
+                    );
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Thank you for great work!

According to [ms document](https://support.office.com/en-us/article/Calculation-operators-and-precedence-in-Excel-48be406d-4975-4d31-b2b8-7af9e0e2878a), ^ takes higher precedence over multiplication operators(* and /).