### PR TITLE
Allow underscore and unicode characters for identifier

### DIFF
--- a/src/parser/Characters.js
+++ b/src/parser/Characters.js
@@ -93,6 +93,12 @@ export default class Characters
         return (/^[a-zA-Z]+$/).test(this.current);
     }
 
+    isUnicode()
+    {
+        // https://stackoverflow.com/questions/2124010/grep-regex-to-match-non-ascii-characters
+        return (/[^\x00-\x7F]+$/).test(this.current);
+    }
+
     /**
      * Returns true if the current character is a digit.
      * @return {boolean} True if is a digit.
@@ -108,6 +114,6 @@ export default class Characters
      */
     isIdentifier()
     {
-        return (this.isAlpha() || this.isDigit() || (/^[\_\$\.]+$/).test(this.current));
+        return (this.isAlpha() || this.isUnicode() || this.isDigit() || (/^[\_\$\.]+$/).test(this.current));
     }
 }

--- a/src/parser/Characters.js
+++ b/src/parser/Characters.js
@@ -108,6 +108,6 @@ export default class Characters
      */
     isIdentifier()
     {
-        return (this.isAlpha() || this.isDigit() || (/^[\$\.]+$/).test(this.current));
+        return (this.isAlpha() || this.isDigit() || (/^[\_\$\.]+$/).test(this.current));
     }
 }

--- a/src/parser/Lexer.js
+++ b/src/parser/Lexer.js
@@ -398,7 +398,7 @@ export default class Lexer extends Characters
             }
 
             // Get identifier
-            if (this.isAlpha() || this.current === UNDERSCORE || this.current === DOLLAR_SIGN)
+            if (this.isAlpha() || this.isUnicode() || this.current === UNDERSCORE || this.current === DOLLAR_SIGN)
             {
                 return this.identifier();
             }

--- a/src/parser/Lexer.js
+++ b/src/parser/Lexer.js
@@ -3,6 +3,7 @@ import Characters from './Characters';
 import Token from './Token';
 
 const START_CHAR = '=';
+const UNDERSCORE = '_';
 const DOLLAR_SIGN = '$';
 const SINGLE_QUOTE = '\'';
 const DOUBLE_QUOTE = '"';
@@ -397,7 +398,7 @@ export default class Lexer extends Characters
             }
 
             // Get identifier
-            if (this.isAlpha() || this.current === DOLLAR_SIGN)
+            if (this.isAlpha() || this.current === UNDERSCORE || this.current === DOLLAR_SIGN)
             {
                 return this.identifier();
             }

--- a/test/parser/Characters.js
+++ b/test/parser/Characters.js
@@ -42,6 +42,20 @@ describe('Characters', () =>
         });
     });
 
+    describe('isUnicode', () =>
+    {
+        it('should return true', () =>
+        {
+            const char = new Characters('à名ひ가🖐');
+
+            while (!char.end)
+            {
+                expect(char.isUnicode()).to.be.ok();
+                char.advance();
+            }
+        });
+    });
+
     describe('isDigit', () =>
     {
         it('should return true', () =>

--- a/test/parser/Lexer.js
+++ b/test/parser/Lexer.js
@@ -181,6 +181,11 @@ describe('Lexer', () =>
             lexer.next(); // Skip equal sign
             expect(lexer.next()).to.be.eql(new Token(TOKENS.SHEET, 'SHEET1'));
             expect(lexer.next()).to.be.eql(new Token(TOKENS.ID, 'A1'));
+
+            lexer.text = '=_Sheet1!A1';
+            lexer.next(); // Skip equal sign
+            expect(lexer.next()).to.be.eql(new Token(TOKENS.SHEET, '_SHEET1'));
+            expect(lexer.next()).to.be.eql(new Token(TOKENS.ID, 'A1'));
         });
 
         it('should return a cell or reference', () =>

--- a/test/parser/Lexer.js
+++ b/test/parser/Lexer.js
@@ -186,6 +186,11 @@ describe('Lexer', () =>
             lexer.next(); // Skip equal sign
             expect(lexer.next()).to.be.eql(new Token(TOKENS.SHEET, '_SHEET1'));
             expect(lexer.next()).to.be.eql(new Token(TOKENS.ID, 'A1'));
+
+            lexer.text = '=à名ひ가🖐!A1';
+            lexer.next(); // Skip equal sign
+            expect(lexer.next()).to.be.eql(new Token(TOKENS.SHEET, 'À名ひ가🖐'));
+            expect(lexer.next()).to.be.eql(new Token(TOKENS.ID, 'A1'));
         });
 
         it('should return a cell or reference', () =>


### PR DESCRIPTION
This PR allows additional characters (`_` and unicode) for identifier.

https://docs.microsoft.com/en-us/sql/odbc/microsoft/table-name-limitations